### PR TITLE
Give users the possibility to set the exit code in optParse

### DIFF
--- a/src/optParse.ml
+++ b/src/optParse.ml
@@ -542,6 +542,7 @@ module OptParser =
 
     type t = { 
       op_usage : string;
+      op_status : int;
       op_suppress_usage : bool;
       op_prog : string;
 
@@ -620,12 +621,13 @@ module OptParser =
       in
       RefList.add parent.og_children g; g
 
-    let make ?(usage = "%prog [options]") ?description ?version
+    let make ?(usage = "%prog [options]") ?(status = 1) ?description ?version
       ?(suppress_usage = false) ?(suppress_help = false) ?prog 
       ?(formatter = Formatter.indented_formatter ()) () =
       let optparser =
         {
           op_usage = usage; 
+          op_status = status;
           op_suppress_usage = suppress_usage;
           op_prog = Option.default (Filename.basename Sys.argv.(0)) prog;
           op_formatter = formatter; 
@@ -658,11 +660,11 @@ module OptParser =
           unprogify optparser
             (optparser.op_formatter.format_usage optparser.op_usage) ^ eol
 
-    let error optparser ?(chn = stderr) ?(status = 1) message =
+    let error optparser ?(chn = stderr) ?status message =
       fprintf chn "%s%s: %s\n" (format_usage optparser "\n") optparser.op_prog
         message;
       flush chn;
-      exit status
+      exit (Option.default optparser.op_status status)
 
     let usage optparser ?(chn = stdout) () =
       let rec loop g =

--- a/src/optParse.mli
+++ b/src/optParse.mli
@@ -365,7 +365,7 @@ module OptParser :
 
     (** {6 Option parser creation} *)
 
-    val make : ?usage: string -> ?description: string -> ?version: string ->
+    val make : ?usage: string -> ?status: int -> ?description: string -> ?version: string ->
       ?suppress_usage: bool -> ?suppress_help: bool -> ?prog: string ->
       ?formatter: Formatter.t -> unit -> t
     (** Creates a new option parser with the given options.
@@ -379,6 +379,8 @@ module OptParser :
       executable.
 
       @param suppress_usage Suppress the usage message if set.
+
+      @param status Set the program exit status (default is 1).
 
       @param suppress_help Suppress the 'help' option which is
       otherwise added by default.
@@ -445,7 +447,7 @@ module OptParser :
     (** Display an error message and exit the program. The error
       message is printed to the channel [chn] (default is
       [Pervasives.stderr]) and the program exits with exit status
-      [status] (default is 1). *)
+      [status] (default depends on [t] : see [make]). *)
 
     val usage : t -> ?chn: out_channel -> unit -> unit
     (** Display the usage message to the channel [chn] (default is


### PR DESCRIPTION
This patch breaks the current API. Add a new optional parameter to OptParse.OptParser.make and remove an optional parameter from OptParse.OptParser.error.

My use case : my application (dose-distcheck) uses exist codes in a more liberal way : Exit codes 0-63 indicate a normal termination of the program, codes 64-127 indicate abnormal termination of the program. As it stands it is impossible to catch the exit status due to an parse error in the options. This patch adds this possibility. Another way would be not to exit directly, but to raise an exception and let the user to deal with the parsing error. 