### PR TITLE
Run git command in the current directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-VERSION:=$(shell git describe --always --long)
+VERSION:=$(shell git --git-dir="$PWD/.git" describe --always --long)
 RELEASE:=1.7.1
 
 ifndef VERSION


### PR DESCRIPTION
If we execute the command directly, it will read the hash from a parent dir. Make sure it's executed in the current directory.