### PR TITLE
Fix build under OCaml 4.05

### DIFF
--- a/src/configure.ml
+++ b/src/configure.ml
@@ -3,5 +3,6 @@ let () =
   print_endline (if Sys.ocaml_version >= "4.02.0" then "-D OCAML4_02 " else "");
   print_endline (if Sys.ocaml_version >= "4.03.0" then "-D OCAML4_03 " else "");
   print_endline (if Sys.ocaml_version >= "4.04.0" then "-D OCAML4_04 " else "");
+  print_endline (if Sys.ocaml_version >= "4.05.0" then "-D OCAML4_05 " else "");
   let (_:int) = Sys.command "ocamlfind query -format \"-D WITH_BYTES\" bytes" in ();
   exit 0

--- a/src/extHashtbl.mli
+++ b/src/extHashtbl.mli
@@ -132,6 +132,9 @@ module type S =
     val add : 'a t -> key -> 'a -> unit
     val remove : 'a t -> key -> unit
     val find : 'a t -> key -> 'a
+#ifdef OCAML4_05
+    val find_opt : 'a t -> key -> 'a option
+#endif
     val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key -> 'a -> unit
     val mem : 'a t -> key -> bool
@@ -167,6 +170,9 @@ module type SeededS =
     val add : 'a t -> key -> 'a -> unit
     val remove : 'a t -> key -> unit
     val find : 'a t -> key -> 'a
+#ifdef OCAML4_05
+    val find_opt : 'a t -> key -> 'a option
+#endif
     val find_all : 'a t -> key -> 'a list
     val replace : 'a t -> key -> 'a -> unit
     val mem : 'a t -> key -> bool


### PR DESCRIPTION
Note: if the PR is good, I think it would be nice to make an extlib release with the change (1.7.2?) as soon as reasonable possibly. The reason is that extlib's failure on 4.05 currently holds back some package from being tested under 4.05, and having them able to build would help testing before the release.