### PR TITLE
GNU *Lesser* General Public License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,18 @@
-The Library is distributed under the terms of the GNU Library General
+The Library is distributed under the terms of the GNU Lesser General
 Public License version 2 (included below).
 
-As a special exception to the GNU Library General Public License, you
+As a special exception to the GNU Lesser General Public License, you
 may link, statically or dynamically, a "work that uses the Library"
 with a publicly distributed version of the Library to produce an
 executable file containing portions of the Library, and distribute
 that executable file under terms of your choice, without any of the
-additional requirements listed in clause 6 of the GNU Library General
-Public License.  By "a publicly distributed version of the Library",
+additional requirements listed in clause 6 of the GNU Lesser General
+Public License. By "a publicly distributed version of the Library",
 we mean either the unmodified Library as distributed, or a
 modified version of the Library that is distributed under the
-conditions defined in clause 3 of the GNU Library General Public
-License.  This exception does not however invalidate any other reasons
-why the executable file might be covered by the GNU Library General
+conditions defined in clause 2 of the GNU Lesser General Public
+License. This exception does not however invalidate any other reasons
+why the executable file might be covered by the GNU Lesser General
 Public License.
 
 ------------


### PR DESCRIPTION
It is GNU *Lesser* General Public License, not GNU *Library* General Public License according to the license text and file headers.

The Library GPL is old: https://www.gnu.org/licenses/old-licenses/lgpl-2.0.en.html