### PR TITLE
Fix 32bit builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,31 @@ language: c
 sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
-env:
-  - OCAML_VERSION=4.02
-  - OCAML_VERSION=4.03
-  - OCAML_VERSION=4.04
-  - OCAML_VERSION=4.05
-  - OCAML_VERSION=4.06
-os:
-  - linux
-  - osx
+matrix:
+  include:
+  - env: OCAML_VERSION=4.02
+    os: osx
+  - env: OCAML_VERSION=4.03
+    os: osx
+  - env: OCAML_VERSION=4.04
+    os: osx
+  - env: OCAML_VERSION=4.05
+    os: osx
+  - env: OCAML_VERSION=4.06
+    os: osx
+  - env: OCAML_VERSION=4.02
+    os: linux
+  - env: OCAML_VERSION=4.03
+    os: linux
+  - env: OCAML_VERSION=4.04
+    os: linux
+  - env: OCAML_VERSION=4.05
+    os: linux
+  - env: OCAML_VERSION=4.06
+    os: linux
+  - env: OCAML_VERSION=4.06 OPAM_SWITCH=4.06.1+32bit
+    os: linux
+    addons:
+      apt:
+        packages:
+        - gcc-multilib

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+Next (????-??-??)
+ * IO: restore compilation on 32-bit (broken in 1.7.3)
+
 1.7.4 (2018-03-12)
  * fix tests with OCaml 4.06
 

--- a/src/IO.ml
+++ b/src/IO.ml
@@ -573,9 +573,15 @@ let write_i31 ch n =
   if n < -0x4000_0000 || n > 0x3FFF_FFFF then raise (Overflow "write_i31");
   write_32 ch n
 
-let write_i32 ch n =
-  if n < -0x8000_0000 || n > 0x7FFF_FFFF then raise (Overflow "write_i32");
-  write_32 ch n
+let write_i32 =
+  let f l ch n =
+    if n < l || n > 0x7FFF_FFFF then raise (Overflow "write_i32");
+    write_32 ch n
+  in
+  if Sys.word_size = 32 then
+    fun ch -> f min_int ch
+  else
+    fun ch -> f (Nativeint.to_int (-0x8000_0000n)) ch
 
 let write_real_i32 ch n =
   let base = Int32.to_int n in
@@ -677,9 +683,15 @@ let write_i31 ch n =
   if n < -0x4000_0000 || n > 0x3FFF_FFFF then raise (Overflow "write_i31");
   write_32 ch n
 
-let write_i32 ch n =
-  if n < -0x8000_0000 || n > 0x7FFF_FFFF then raise (Overflow "write_i32");
-  write_32 ch n
+let write_i32 =
+  let f l ch n =
+    if n < l || n > 0x7FFF_FFFF then raise (Overflow "write_i32");
+    write_32 ch n
+  in
+  if Sys.word_size = 32 then
+    fun ch -> f min_int ch
+  else
+    fun ch -> f (Nativeint.to_int (-0x8000_0000n)) ch
 
 let write_real_i32 ch n =
   let base = Int32.to_int n in

--- a/test/test_IO.ml
+++ b/test/test_IO.ml
@@ -73,7 +73,7 @@ let test_u16 () =
 
 let test_i31 () =
   let values = [~-0x40000000;-1;0;1;0x3FFFFFFF] in
-  let invalid = [~-0x40000001;0x40000000] in
+  let invalid = if Sys.word_size = 32 then [] else [~-0x40000001;0x40000000] in
   let test = test_write_read values invalid string_of_int in
   test IO.write_i31 IO.read_i31;
   test IO.BigEndian.write_i31 IO.BigEndian.read_i31;


### PR DESCRIPTION
Version 1.7.3 breaks building on 32-bit. This PR does three things:
 - Travis matrix includes a 32-bit Linux build (yaml stupidity meant I had to expand the matrix, so I put the mac builds first while I was there, as @jpdeplaix has found that accelerates their scheduling)
 - IO.ml is tweaked to allow compilation on 32-bit. I don't like the fact it involves running something at startup, so other suggestions welcome. I guess it could also be pre-processed, but I like that even less... or it could wait for metaocaml-extlib, and be staged.
 - The overflow tests for write_i31 don't make sense on 32-bit, so they're disabled.