### PR TITLE
Fix Dllist.skip

### DIFF
--- a/src/dllist.ml
+++ b/src/dllist.ml
@@ -126,14 +126,14 @@ let next node = node.next
 let prev node = node.prev
 
 let skip node idx =
-  let m = if idx > 0 then -1 else 1 in
+  let f = if idx > 0 then next else prev in
   let rec loop idx n =
     if idx == 0 then
       n
     else
-      loop (idx + m) n.next
+      loop (idx - 1) (f n)
   in
-  loop idx node
+  loop (abs idx) node
 
 let rev node =
   let rec loop next n =

--- a/test/test_Dllist.ml
+++ b/test/test_Dllist.ml
@@ -47,9 +47,17 @@ let test_regression_2 () =
   ignore (Dllist.promote lst);
   assert (Dllist.length lst = 2)  (* returned 1, but should return 2 *)
 
+let skip_both_ways () =
+  let lst = Dllist.create "left" in
+  ignore (Dllist.add lst "right");
+  let lm = Dllist.append lst "middle" in
+  assert (Dllist.get (Dllist.skip lm 1) = "right");
+  assert (Dllist.get (Dllist.skip lm (-1)) = "left") (* returned right *)
+
 let () = 
   Util.register "Dllist" [
     "simple", test_simple;
     "regression_1", test_regression_1;
     "regression_2", test_regression_2;
+    "skip_both_ways", skip_both_ways;
   ]


### PR DESCRIPTION
skip had the same behavior no matter the sign of the parameter  
Also added a test for it