### PR TITLE
try bit representation (closes #50)

### DIFF
--- a/test/test_IO.ml
+++ b/test/test_IO.ml
@@ -101,7 +101,7 @@ let test_bits () =
   let input = Bytes.make 4 (Char.chr 0xFF) in
   let ch = IO.input_bits (IO.input_bytes input) in
   let value = IO.read_bits ch 31 in
-  assert (value = 2147483647);
+  assert (value = (0b1111111111111111111111111111111));
   ()
 
 let () =


### PR DESCRIPTION
hopefully fix the test for #51 for 32-bit ocaml (we don't care about the number, we care about bits)