### PR TITLE
Add support for OCaml 4.12

### DIFF
--- a/src/extHashtbl.ml
+++ b/src/extHashtbl.ml
@@ -22,7 +22,7 @@
 module Hashtbl =
   struct
 
-#if OCAML >= 400
+#if OCAML >= 400 && OCAML < 412
   external old_hash_param :
     int -> int -> 'a -> int = "caml_hash_univ_param" "noalloc"
 #endif
@@ -114,7 +114,11 @@ module Hashtbl =
     (* compatibility with old hash tables *)
     if Obj.size (Obj.repr h) >= 3
     then (seeded_hash_param 10 100 (h_conv h).seed key) land (Array.length (h_conv h).data - 1)
+  #if OCAML >= 412
+    else failwith "Old hash function not supported anymore"
+  #else
     else (old_hash_param 10 100 key) mod (Array.length (h_conv h).data)
+  #endif
 #else
   let key_index h key = (hash key) mod (Array.length (h_conv h).data)
 #endif

--- a/src/extList.ml
+++ b/src/extList.ml
@@ -380,7 +380,7 @@ let combine l1 l2 =
   loop dummy l1 l2;
   dummy.tl
 
-let sort ?(cmp=compare) = List.sort cmp
+let sort ?(cmp=Pervasives.compare) = List.sort cmp
 
 #if OCAML < 406
 let rec init size f =


### PR DESCRIPTION
OCaml 4.12 added `List.compare` and now shadows `Pervasives.compare` in this particular context.