### PR TITLE
OCaml 5.00 support

### DIFF
--- a/src/IO.ml
+++ b/src/IO.ml
@@ -310,19 +310,19 @@ let input_channel ch =
         End_of_file -> raise No_more_input
     );
     in_input = (fun s p l ->
-      let n = Pervasives.input ch s p l in
+      let n = Stdlib.input ch s p l in
       if n = 0 then raise No_more_input;
       n
     );
-    in_close = (fun () -> Pervasives.close_in ch);
+    in_close = (fun () -> Stdlib.close_in ch);
   }
 
 let output_channel ch =
   {
     out_write = (fun c -> output_char ch c);
-    out_output = (fun s p l -> Pervasives.output ch s p l; l);
-    out_close = (fun () -> Pervasives.close_out ch);
-    out_flush = (fun () -> Pervasives.flush ch);
+    out_output = (fun s p l -> Stdlib.output ch s p l; l);
+    out_close = (fun () -> Stdlib.close_out ch);
+    out_flush = (fun () -> Stdlib.flush ch);
   }
 
 let input_enum e =
@@ -539,7 +539,7 @@ let read_double ch =
   Int64.float_of_bits (read_i64 ch)
 
 let write_byte o n =
-  (* doesn't test bounds of n in order to keep semantics of Pervasives.output_byte *)
+  (* doesn't test bounds of n in order to keep semantics of Stdlib.output_byte *)
   write o (Char.unsafe_chr (n land 0xFF))
 
 let write_string o s =

--- a/src/extArray.mli
+++ b/src/extArray.mli
@@ -118,7 +118,9 @@ sig
   val create_float : int -> float array
 #endif
 
+#if OCAML < 500
   val make_float : int -> float array
+#endif
 
 #if OCAML >= 406
   module Floatarray :
@@ -150,10 +152,14 @@ sig
   external get : 'a array -> int -> 'a = "%array_safe_get"
   external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
   external make : int -> 'a -> 'a array = "caml_make_vect"
+#if OCAML < 500
   external create : int -> 'a -> 'a array = "caml_make_vect"
+#endif
   val init : int -> (int -> 'a) -> 'a array
   val make_matrix : int -> int -> 'a -> 'a array array
+#if OCAML < 500
   val create_matrix : int -> int -> 'a -> 'a array array
+#endif
   val append : 'a array -> 'a array -> 'a array
   val concat : 'a array list -> 'a array
   val sub : 'a array -> int -> int -> 'a array

--- a/src/extList.ml
+++ b/src/extList.ml
@@ -407,7 +407,7 @@ let combine l1 l2 =
   loop dummy l1 l2;
   dummy.tl
 
-let sort ?(cmp=Pervasives.compare) = List.sort cmp
+let sort ?(cmp=Stdlib.compare) = List.sort cmp
 
 #if OCAML < 406
 let rec init size f =

--- a/src/extString.mli
+++ b/src/extString.mli
@@ -176,21 +176,29 @@ module String :
 
   val length : string -> int
   val get : string -> int -> char
+#if OCAML < 500
   val set : Bytes.t -> int -> char -> unit
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated "Use Bytes.set instead."]
 #endif
+#if OCAML < 500
   val create : int -> Bytes.t
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated "Use Bytes.create instead."]
 #endif
   val make : int -> char -> string
+#if OCAML < 500
   val copy : string -> string
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated]
 #endif
   val sub : string -> int -> int -> string
+#if OCAML < 500
   val fill : Bytes.t -> int -> int -> char -> unit
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated "Use Bytes.fill instead."]
 #endif
@@ -210,22 +218,30 @@ module String :
   val contains_from : string -> int -> char -> bool
   val rcontains_from : string -> int -> char -> bool
 
+#if OCAML < 500
   val uppercase : string -> string
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated "Use String.uppercase_ascii instead."]
 #endif
 
+#if OCAML < 500
   val lowercase : string -> string
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated "Use String.lowercase_ascii instead."]
 #endif
 
+#if OCAML < 500
   val capitalize : string -> string
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated "Use String.capitalize_ascii instead."]
 #endif
 
+#if OCAML < 500
   val uncapitalize : string -> string
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated "Use String.uncapitalize_ascii instead."]
 #endif
@@ -244,12 +260,16 @@ module String :
   (**/**)
 
   external unsafe_get : string -> int -> char = "%string_unsafe_get"
+#if OCAML < 500
   val unsafe_set : Bytes.t -> int -> char -> unit
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated]
 #endif
   val unsafe_blit : string -> int -> Bytes.t -> int -> int -> unit
+#if OCAML < 500
   val unsafe_fill : Bytes.t -> int -> int -> char -> unit
+#endif
 #if OCAML >= 402
   [@@ocaml.deprecated]
 #endif

--- a/src/uTF8.ml
+++ b/src/uTF8.ml
@@ -182,7 +182,7 @@ let rec iter_aux proc s i =
 
 let iter proc s = iter_aux proc s 0
 
-let compare s1 s2 = Pervasives.compare s1 s2
+let compare s1 s2 = Stdlib.compare s1 s2
 
 exception Malformed_code
 


### PR DESCRIPTION
OCaml 5.00 is removing some long-deprecated functions. 

This PR also removes them from the interface in those versions. If you prefer a compatibility approach, I can set up aliases instead.