### PR TITLE
Add support for OCaml 5.0

### DIFF
--- a/opam
+++ b/opam
@@ -26,7 +26,7 @@ build: [
 ]
 install: [ [make "minimal=1" "install"] ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.08"}
   "ocamlfind" {build}
   "cppo" {build}
   "base-bytes" {build}

--- a/src/IO.ml
+++ b/src/IO.ml
@@ -310,19 +310,19 @@ let input_channel ch =
         End_of_file -> raise No_more_input
     );
     in_input = (fun s p l ->
-      let n = Pervasives.input ch s p l in
+      let n = Stdlib.input ch s p l in
       if n = 0 then raise No_more_input;
       n
     );
-    in_close = (fun () -> Pervasives.close_in ch);
+    in_close = (fun () -> Stdlib.close_in ch);
   }
 
 let output_channel ch =
   {
     out_write = (fun c -> output_char ch c);
-    out_output = (fun s p l -> Pervasives.output ch s p l; l);
-    out_close = (fun () -> Pervasives.close_out ch);
-    out_flush = (fun () -> Pervasives.flush ch);
+    out_output = (fun s p l -> Stdlib.output ch s p l; l);
+    out_close = (fun () -> Stdlib.close_out ch);
+    out_flush = (fun () -> Stdlib.flush ch);
   }
 
 let input_enum e =
@@ -539,7 +539,7 @@ let read_double ch =
   Int64.float_of_bits (read_i64 ch)
 
 let write_byte o n =
-  (* doesn't test bounds of n in order to keep semantics of Pervasives.output_byte *)
+  (* doesn't test bounds of n in order to keep semantics of Stdlib.output_byte *)
   write o (Char.unsafe_chr (n land 0xFF))
 
 let write_string o s =

--- a/src/extArray.ml
+++ b/src/extArray.ml
@@ -216,4 +216,10 @@ let create_float = make_float
 #endif
 #endif
 
+#if OCAML >= 500
+external create : int -> 'a -> 'a array = "caml_make_vect"
+let create_matrix = make_matrix
+let make_float = create_float
+#endif
+
 end

--- a/src/extList.ml
+++ b/src/extList.ml
@@ -407,7 +407,7 @@ let combine l1 l2 =
   loop dummy l1 l2;
   dummy.tl
 
-let sort ?(cmp=Pervasives.compare) = List.sort cmp
+let sort ?(cmp=Stdlib.compare) = List.sort cmp
 
 #if OCAML < 406
 let rec init size f =

--- a/src/extString.ml
+++ b/src/extString.ml
@@ -328,4 +328,17 @@ let rindex_from_opt s i c =
 
 #endif
 
+#if OCAML >= 500
+let create = Bytes.create
+let set = Bytes.set
+let unsafe_set = Bytes.unsafe_set
+let copy x = Bytes.unsafe_to_string (Bytes.copy (Bytes.unsafe_of_string x))
+let fill = Bytes.fill
+let unsafe_fill = Bytes.unsafe_fill
+let uppercase = uppercase_ascii
+let lowercase = lowercase_ascii
+let capitalize = capitalize_ascii
+let uncapitalize = uncapitalize_ascii
+#endif
+
 end

--- a/src/uTF8.ml
+++ b/src/uTF8.ml
@@ -182,7 +182,7 @@ let rec iter_aux proc s i =
 
 let iter proc s = iter_aux proc s 0
 
-let compare s1 s2 = Pervasives.compare s1 s2
+let compare s1 s2 = Stdlib.compare s1 s2
 
 exception Malformed_code
 


### PR DESCRIPTION
This PR bumps the minimal required version to 4.08 but a version adding `stdlib-shims` as a dependency can be made instead. I just went with the easiest thing so it can be improved later however you like.