### PR TITLE
ocaml-extlib: fix Makefile to include bytecode-only target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ endif
 build:
 	$(MAKE) -C src build
 
+# bytecode-only target:
+all:
+	$(MAKE) -C src all
+
 install:
 	$(MAKE) -C src VERSION=$(VERSION) install
 


### PR DESCRIPTION
Makefile in src has all needed targets, but main Makefile does not. In result, trying to build `all` (as readme recommends for bytecode-only platforms) fails with “no rule to make target all”.
This PR adds the target into the main Makefile, which fixes the failure.