### PR TITLE
Add labels to some ExtString functions + add ExtString.empty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 unreleased
 * breaking change: ExtString.starts_with type updated to match stdlib (use labelled ~prefix)
 * breaking change: ExtString.ends_with type updated to match stdlib (use labelled ~suffix)
+* breaking change: ExtString.exists use labelled ~sub argument
 
 1.7.9 (2022-08-05)
 * build with OCaml 5 (Kate)

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 unreleased
 * breaking change: ExtString.starts_with type updated to match stdlib (use labelled ~prefix)
+* breaking change: ExtString.ends_with type updated to match stdlib (use labelled ~suffix)
 
 1.7.9 (2022-08-05)
 * build with OCaml 5 (Kate)

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ unreleased
 * breaking change: ExtString.starts_with type updated to match stdlib (use labelled ~prefix)
 * breaking change: ExtString.ends_with type updated to match stdlib (use labelled ~suffix)
 * breaking change: ExtString.exists use labelled ~sub argument
+* add ExtString.empty
 
 1.7.9 (2022-08-05)
 * build with OCaml 5 (Kate)

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+unreleased
+* breaking change: ExtString.starts_with type updated to match stdlib (use labelled ~prefix)
+
 1.7.9 (2022-08-05)
 * build with OCaml 5 (Kate)
 * minimum supported version is OCaml 4.02 now

--- a/src/extString.ml
+++ b/src/extString.ml
@@ -79,7 +79,7 @@ let find_from str pos sub =
 
 let find str sub = find_from str 0 sub
 
-let exists str sub =
+let exists str ~sub =
   try
     ignore(find str sub);
     true

--- a/src/extString.ml
+++ b/src/extString.ml
@@ -36,6 +36,10 @@ let init len f =
   Bytes.unsafe_to_string s
 #endif
 
+#if OCAML < 413
+let empty = ""
+#endif
+
 let starts_with str ~prefix:p =
   if length str < length p then 
     false

--- a/src/extString.ml
+++ b/src/extString.ml
@@ -36,7 +36,7 @@ let init len f =
   Bytes.unsafe_to_string s
 #endif
 
-let starts_with str p =
+let starts_with str ~prefix:p =
   if length str < length p then 
     false
   else

--- a/src/extString.ml
+++ b/src/extString.ml
@@ -47,7 +47,7 @@ let starts_with str ~prefix:p =
     in
     loop str p 0
 
-let ends_with s e =
+let ends_with s ~suffix:e =
   if length s < length e then
     false
   else

--- a/src/extString.mli
+++ b/src/extString.mli
@@ -104,8 +104,8 @@ module String :
   val ends_with : string -> string -> bool
   (** [ends_with s x] returns true if the string [s] is ending with [x]. *)
 
-  val starts_with : string -> string -> bool
-  (** [starts_with s x] return true if [s] is starting with [x]. *)
+  val starts_with : string -> prefix:string -> bool
+  (** [starts_with s ~prefix] return true if [s] is starting with [prefix]. *)
 
   val enum : string -> char Enum.t
   (** Returns an enumeration of the characters of a string.*)

--- a/src/extString.mli
+++ b/src/extString.mli
@@ -101,8 +101,8 @@ module String :
   (** Returns the float represented by the given string or
       raises Invalid_string if the string does not represent a float. *)
 
-  val ends_with : string -> string -> bool
-  (** [ends_with s x] returns true if the string [s] is ending with [x]. *)
+  val ends_with : string -> suffix:string -> bool
+  (** [ends_with s ~suffix] returns true if the string [s] is ending with [suffix]. *)
 
   val starts_with : string -> prefix:string -> bool
   (** [starts_with s ~prefix] return true if [s] is starting with [prefix]. *)

--- a/src/extString.mli
+++ b/src/extString.mli
@@ -143,8 +143,8 @@ module String :
   (** Returns the string without the chars if they are at the beginning or
       at the end of the string. By default chars are " \t\r\n". *)
 
-  val exists : string -> string -> bool
-  (** [exists str sub] returns true if [sub] is a substring of [str] or
+  val exists : string -> sub:string -> bool
+  (** [exists str ~sub] returns true if [sub] is a substring of [str] or
       false otherwise. *)
 
   val replace_chars : (char -> string) -> string -> string

--- a/src/extString.mli
+++ b/src/extString.mli
@@ -27,6 +27,9 @@ exception Invalid_string
 module String :
   sig
 
+  val empty: string
+  (** The empty string. *)
+
   (** {6 New Functions} *)
 
   val init : int -> (int -> char) -> string

--- a/src/optParse.ml
+++ b/src/optParse.ml
@@ -456,7 +456,7 @@ module Formatter =
               fill ~initial_indent:(!indent) ~subsequent_indent:(!indent)
                 description (width - !indent)
             in
-              if not (String.ends_with x "\n") then x ^ "\n\n" else x ^ "\n");
+              if not (String.ends_with x ~suffix:"\n") then x ^ "\n\n" else x ^ "\n");
         
         format_option =
          fun names metavars help ->
@@ -489,7 +489,7 @@ module Formatter =
            let contents =
              Buffer.contents buf
            in
-             if String.length contents > 0 && not (String.ends_with contents "\n") then
+             if String.length contents > 0 && not (String.ends_with contents ~suffix:"\n") then
                contents ^ "\n"
              else
                contents

--- a/src/optParse.ml
+++ b/src/optParse.ml
@@ -113,10 +113,10 @@ module GetOpt =
           [] -> []
         | arg :: args' ->
             if arg = "--" then args'
-            else if String.starts_with arg "--" then
+            else if String.starts_with arg ~prefix:"--" then
               loop (gather_long_opt arg args')
             else if arg = "-" then begin other arg; loop args' end
-            else if String.starts_with arg "-" then
+            else if String.starts_with arg ~prefix:"-" then
               loop (gather_short_opt arg 1 args')
             else begin other arg; loop args' end
       in

--- a/test/test_ExtString.ml
+++ b/test/test_ExtString.ml
@@ -25,12 +25,12 @@ module S = String
 
 let t_starts_with () = 
   let s0 = "foo" in
-  assert (S.starts_with s0 s0);
-  assert (S.starts_with s0 "f");
-  assert (not (S.starts_with s0 "bo"));
-  assert (not (S.starts_with "" "foo"));
-  assert (S.starts_with s0 "");
-  assert (S.starts_with "" "")
+  assert (S.starts_with s0 ~prefix:s0);
+  assert (S.starts_with s0 ~prefix:"f");
+  assert (not (S.starts_with s0 ~prefix:"bo"));
+  assert (not (S.starts_with "" ~prefix:"foo"));
+  assert (S.starts_with s0 ~prefix:"");
+  assert (S.starts_with "" ~prefix:"")
 
 let t_ends_with () = 
   let s0 = "foo" in

--- a/test/test_ExtString.ml
+++ b/test/test_ExtString.ml
@@ -34,13 +34,13 @@ let t_starts_with () =
 
 let t_ends_with () = 
   let s0 = "foo" in
-  assert (S.ends_with s0 "foo");
-  assert (S.ends_with s0 "oo");
-  assert (S.ends_with s0 "o");
-  assert (S.ends_with s0 "");
-  assert (S.ends_with "" "");
-  assert (not (S.ends_with "" "b"));
-  assert (not (S.ends_with s0 "f"))
+  assert (S.ends_with s0 ~suffix:"foo");
+  assert (S.ends_with s0 ~suffix:"oo");
+  assert (S.ends_with s0 ~suffix:"o");
+  assert (S.ends_with s0 ~suffix:"");
+  assert (S.ends_with "" ~suffix:"");
+  assert (not (S.ends_with "" ~suffix:"b"));
+  assert (not (S.ends_with s0 ~suffix:"f"))
 
 let t_map () =
   let s0 = "foobar" in
@@ -112,10 +112,10 @@ let t_strip () =
   assert (S.strip ~chars:"1" s = String.sub s 1 (String.length s-1));
   assert (S.strip ~chars:"12" s = String.sub s 2 (String.length s-2));
   assert (S.strip ~chars:"1234" s = "abcd5678");
-  assert (S.ends_with (S.strip ~chars:"8" s) "567");
-  assert (S.ends_with (S.strip ~chars:"87" s) "56");
-  assert (S.ends_with (S.strip ~chars:"86" s) "567");
-  assert (S.ends_with (S.strip ~chars:"" s) "5678")
+  assert (S.ends_with (S.strip ~chars:"8" s) ~suffix:"567");
+  assert (S.ends_with (S.strip ~chars:"87" s) ~suffix:"56");
+  assert (S.ends_with (S.strip ~chars:"86" s) ~suffix:"567");
+  assert (S.ends_with (S.strip ~chars:"" s) ~suffix:"5678")
 
 let t_nsplit () =
   let s = "testsuite" in


### PR DESCRIPTION
Add labels to `ExtString.starts_with`,`ExtString.ends_with` and `ExtString.exists`. I also added the `ExtString.empty` to match stdlib