### PR TITLE
Add support for OCaml 5.3

### DIFF
--- a/src/extArray.mli
+++ b/src/extArray.mli
@@ -112,7 +112,9 @@ sig
 
   (** These functions are reimplemented in extlib when they are missing from the stdlib *)
 
-#if OCAML >= 403
+#if OCAML >= 503
+  external create_float : int -> float array = "caml_array_create_float"
+#elif OCAML >= 403
   external create_float : int -> float array = "caml_make_float_vect"
 #else
   val create_float : int -> float array
@@ -149,7 +151,11 @@ sig
   external length : 'a array -> int = "%array_length"
   external get : 'a array -> int -> 'a = "%array_safe_get"
   external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
+#if OCAML >= 503
+  external make : int -> 'a -> 'a array = "caml_array_make"
+#else
   external make : int -> 'a -> 'a array = "caml_make_vect"
+#endif
   external create : int -> 'a -> 'a array = "caml_make_vect"
   val init : int -> (int -> 'a) -> 'a array
   val make_matrix : int -> int -> 'a -> 'a array array


### PR DESCRIPTION
Changed in https://github.com/ocaml/ocaml/pull/13003
```
#=== ERROR while compiling extlib.1.7.9 =======================================#
# context              2.2.0~beta3~dev | linux/x86_64 | ocaml-variants.5.3.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.3/.opam-switch/build/extlib.1.7.9
# command              ~/.opam/5.3/bin/dune build -p extlib -j 1
# exit-code            1
# env-file             ~/.opam/log/extlib-20-35b0de.env
# output-file          ~/.opam/log/extlib-20-35b0de.out
### output ###
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlc.opt -w -40 -w -3-6-9-27-32-33-35-39-50 -g -bin-annot -I src/.extlib.objs/byte -intf-suffix .ml -no-alias-deps -o src/.extlib.objs/byte/extArray.cmo -c -impl src/extArray.pp.ml)
# File "src/extArray.pp.ml", line 1:
# Error: The implementation "src/extArray.pp.ml"
#        does not match the interface "src/extArray.pp.ml":  ... In module "Array":
#        Values do not match:
#          external create_float : int -> float array
#            = "caml_array_create_float"
#        is not included in
#          external create_float : int -> float array = "caml_make_float_vect"
#        The names of the primitives are not the same
#        File "src/extArray.mli", line 116, characters 2-69:
#          Expected declaration
#        File "array.mli", line 66, characters 0-69: Actual declaration
# (cd _build/default && /home/opam/.opam/5.3/bin/ocamlopt.opt -w -40 -w -3-6-9-27-32-33-35-39-50 -g -I src/.extlib.objs/byte -I src/.extlib.objs/native -intf-suffix .ml -no-alias-deps -o src/.extlib.objs/native/extArray.cmx -c -impl src/extArray.pp.ml)
# File "src/extArray.pp.ml", line 1:
# Error: The implementation "src/extArray.pp.ml"
#        does not match the interface "src/extArray.pp.ml":  ... In module "Array":
#        Values do not match:
#          external create_float : int -> float array
#            = "caml_array_create_float"
#        is not included in
#          external create_float : int -> float array = "caml_make_float_vect"
#        The names of the primitives are not the same
#        File "src/extArray.mli", line 116, characters 2-69:
#          Expected declaration
#        File "array.mli", line 66, characters 0-69: Actual declaration
```