### PR TITLE
Add a missing constraint to cppo

### DIFF
--- a/extlib.opam
+++ b/extlib.opam
@@ -22,7 +22,7 @@ authors: [
 depends: [
   "dune" {>= "1.0"}
   "ocaml" {>= "4.02"}
-  "cppo" {build}
+  "cppo" {build & >= "1.0.1"}
 ]
 synopsis:
   "A complete yet small extension for OCaml standard library"


### PR DESCRIPTION
Uses #elif together with #else since 70906ef872813fa636a15c05187071330a067d06