### PR TITLE
gha: test fewer OCaml versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,18 +10,17 @@ jobs:
       fail-fast: false
       matrix:
         ocaml-version:
-          - 4.02.3
-          - 4.05.0
-          - 4.11.1
-          - 4.14.1
-          - 5.1.0
-          - 5.2.0
+          - "4.02"
+          - "4.05"
+          - "4.11"
+          - "4.14"
+          - "5"
         os:
           - ubuntu-latest
         include:
-          - ocaml-version: 4.14.1
+          - ocaml-version: "4.14"
             os: macos-latest
-          - ocaml-version: 4.14.1
+          - ocaml-version: "4.14"
             os: windows-latest
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Automatically select the latest patch release. Test only the latest minor release in the OCaml 5 series.